### PR TITLE
一部の関数がuseされない

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/src/autoUse.ts
+++ b/src/autoUse.ts
@@ -24,6 +24,7 @@ export class AutoUse extends UseBuilder {
         const fullText = this.selector.getFullText();
 
         const tokensInFullText = fullText
+            .replace(AutoUseRegex.COMMENT, '')
             .split(AutoUseRegex.DELIMITER)
             .filter(s => s !== '') // guarantee the order hash_key => xxx
             .filter((token, idx, arr) =>

--- a/src/autoUseRegex.ts
+++ b/src/autoUseRegex.ts
@@ -29,6 +29,8 @@ export class AutoUseRegex {
 
     static readonly DELIMITER = /\s|\(|;|,/g;
 
+    static readonly COMMENT = /#.*(\n|\r\n)/g;
+
     static readonly EXACT_MATCH_WORD_LOWER_CASE = /^[a-z0-9_]+$/;
 
     static readonly DECLARE = /^(use|my|our|local|sub|package)$/;

--- a/src/autoUseRegex.ts
+++ b/src/autoUseRegex.ts
@@ -27,9 +27,9 @@ export class AutoUseRegex {
     // e.g) Hoge::Fuga::bar;
     static readonly SUB_MODULE = /(([A-Z][a-z0-9]*(::)?)+)::([a-z0-9_]+)(\(|;)/g;
 
-    static readonly DELIMITER = /\s|\(|;/g;
+    static readonly DELIMITER = /\s|\(|;|,/g;
 
     static readonly EXACT_MATCH_WORD_LOWER_CASE = /^[a-z0-9_]+$/;
 
-    static readonly DECLARE = /use|my|our|local|sub|package/;
+    static readonly DECLARE = /^(use|my|our|local|sub|package)$/;
 }

--- a/src/test/suite/autoUse.test.ts
+++ b/src/test/suite/autoUse.test.ts
@@ -40,7 +40,7 @@ suite('AutoUse Test', () => {
         const fullText = selector.getFullText();
         const okFullyQualifiedModule = RegExp(/Hoge::Fuga/).test(fullText);
         const okLibraryModule =
-            RegExp(/use Hoge::Piyo qw\(create_piyo piyo_piyo\)/).test(fullText) &&
+            RegExp(/use Hoge::Piyo qw\(create_piyo my_name piyo_piyo\)/).test(fullText) &&
             RegExp(/use Smart::Args::TypeTiny qw\(args_pos\)/).test(fullText) &&
             !RegExp(/use Smart::Args::TypeTiny::Check/).test(fullText);
 

--- a/src/test/suite/autoUse.test.ts
+++ b/src/test/suite/autoUse.test.ts
@@ -41,9 +41,10 @@ suite('AutoUse Test', () => {
         const okFullyQualifiedModule = RegExp(/Hoge::Fuga/).test(fullText);
         const okLibraryModule =
             RegExp(/use Hoge::Piyo qw\(create_piyo piyo_piyo\)/).test(fullText) &&
-            RegExp(/use Smart::Args::TypeTiny qw\(args_pos\)/);
+            RegExp(/use Smart::Args::TypeTiny qw\(args_pos\)/).test(fullText) &&
+            !RegExp(/use Smart::Args::TypeTiny::Check/).test(fullText);
 
-        assert.ok(okFullyQualifiedModule && okLibraryModule);
+        assert.ok(okFullyQualifiedModule && okLibraryModule, 'success use and checked not used hash key and comment');
 
         test('module having sub already existed', async () => {
             await selector.deleteByRegex(/use .+;\n|\r\n/g);
@@ -55,9 +56,9 @@ suite('AutoUse Test', () => {
             const okFullyQualifiedModule = RegExp(/Hoge::Fuga/).test(fullText);
             const okLibraryModule =
                 RegExp(/use Hoge::Piyo qw\(create_piyo piyo_piyo\)/).test(fullText) &&
-                RegExp(/use Smart::Args::TypeTiny qw\(args args_pos\)/);
+                RegExp(/use Smart::Args::TypeTiny qw\(args args_pos\)/).test(fullText);
 
-            assert.ok(okFullyQualifiedModule && okLibraryModule);
+            assert.ok(okFullyQualifiedModule && okLibraryModule, 'success add sub');
         });
     });
 });

--- a/src/test/testWorkSpace/AutoUse.pm
+++ b/src/test/testWorkSpace/AutoUse.pm
@@ -1,6 +1,6 @@
 package AutoUse;
 use Smart::Args::TypeTiny qw(args_pos);
-use Hoge::Piyo qw(create_piyo piyo_piyo);
+use Hoge::Piyo qw(create_piyo my_name piyo_piyo);
 use Hoge::Fuga;
 
 # check_type is not used
@@ -20,6 +20,7 @@ sub new_from_name {
 sub song {
     Hoge::Fuga->song;
     my $sing = piyo_piyo(times => 2);
+    my $name = my_name;
 }
 
 sub walk {

--- a/src/test/testWorkSpace/AutoUse.pm
+++ b/src/test/testWorkSpace/AutoUse.pm
@@ -3,17 +3,23 @@ use Smart::Args::TypeTiny qw(args_pos);
 use Hoge::Piyo qw(create_piyo piyo_piyo);
 use Hoge::Fuga;
 
+# check_type is not used
 sub new_from_name {
     args_pos my $class => 'Class',
              my $name  => 'Str',
     ;
-    create_piyo;
-    print('}
 
+    my $piyo = create_piyo;
+
+    my $hash = {
+        types => 'types is exported but hash key',
+    };
+}
+
+# check_rule is not used
 sub song {
     Hoge::Fuga->song;
-    piyo_piyo(times => 2);
-    print('
+    my $sing = piyo_piyo(times => 2);
 }
 
 sub walk {

--- a/src/test/testWorkSpace/lib/Hoge/Piyo.pm
+++ b/src/test/testWorkSpace/lib/Hoge/Piyo.pm
@@ -3,14 +3,13 @@ package Hoge::Piyo;
 use Exporter 'import';
 our @EXPORT = get_public_functions;
 
-sub create_piyo {
-    print 'create';
-}
+sub create_piyo {}
 
 sub piyo_piyo {
-    print 'piyopiyo';
 }
 
-sub _args_pos {
-    print('private so not exported');
+sub _args_pos {}
+
+sub my_name {
+    print 'include declare token my';
 }

--- a/src/useBuilder.ts
+++ b/src/useBuilder.ts
@@ -40,8 +40,8 @@ export class UseBuilder {
 
             const useStatement = this.buildUseStatement(packageName, subList);
             if (alreadyDeclaredModuleSub?.length) {
-                const regex = `use ${packageName} qw(\\/|\\()(\\s*\\w+\\s*)*(\\/|\\));\n|\r\n|\r`;
-                await this.selector.deleteByRegex(RegExp(regex));
+                const regex = `use ${packageName} qw\(.*\);(\n|\r\n)`;
+                await this.selector.deleteByRegex(RegExp(regex, 'g'));
             }
             if (useStatement !== '') {
                 useStatements.push(useStatement);

--- a/src/useBuilder.ts
+++ b/src/useBuilder.ts
@@ -35,7 +35,8 @@ export class UseBuilder {
                     .filter(io => !alreadyDeclaredSubList.includes(io.name))
                     .map(fio => fio.name)
                     .concat(alreadyDeclaredSubList)
-                : packageNameToImportObjects[packageName].map(io => io.name);
+                    .sort()
+                : packageNameToImportObjects[packageName].map(io => io.name).sort();
 
             const useStatement = this.buildUseStatement(packageName, subList);
             if (alreadyDeclaredModuleSub?.length) {


### PR DESCRIPTION
- 全文をsplitしたときにdeclareトークンかどうかを完全一致で判定する必要があった
- `,`でもスプリットする必要があった